### PR TITLE
Bugfix: tox for build and push

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,68 @@
+# Tox configuration file
+# Read more under https://tox.readthedocs.org/
+# THIS SCRIPT IS SUPPOSED TO BE AN EXAMPLE. MODIFY IT ACCORDING TO YOUR NEEDS!
+
+[tox]
+minversion = 3.15
+envlist = default
+
+
+[testenv]
+description = invoke pytest to run automated tests
+isolated_build = True
+setenv =
+    TOXINIDIR = {toxinidir}
+passenv =
+    HOME
+extras =
+    testing
+commands =
+    pytest {posargs}
+
+
+[testenv:{clean,build}]
+description =
+    Build (or clean) the package in isolation according to instructions in:
+    https://setuptools.readthedocs.io/en/latest/build_meta.html#how-to-use-it
+    https://github.com/pypa/pep517/issues/91
+    https://github.com/pypa/build
+# NOTE: build is still experimental, please refer to the links for updates/issues
+skip_install = True
+changedir = {toxinidir}
+deps =
+    build: build[virtualenv]
+commands =
+    clean: python -c 'from shutil import rmtree; rmtree("build", True); rmtree("dist", True)'
+    build: python -m build .
+# By default `build` produces wheels, you can also explicitly use the flags `--sdist` and `--wheel`
+
+
+[testenv:{docs,doctests}]
+description = invoke sphinx-build to build the docs/run doctests
+setenv =
+    DOCSDIR = {toxinidir}/docs
+    BUILDDIR = {toxinidir}/docs/_build
+    docs: BUILD = html
+    doctests: BUILD = doctest
+deps =
+    -r {toxinidir}/docs/requirements.txt
+    # ^  requirements.txt shared with Read The Docs
+commands =
+    sphinx-build -b {env:BUILD} -d "{env:BUILDDIR}/doctrees" "{env:DOCSDIR}" "{env:BUILDDIR}/{env:BUILD}" {posargs}
+
+
+[testenv:publish]
+description =
+    Publish the package you have been developing to a package index server.
+    By default, it uses testpypi. If you really want to publish your package
+    to be publicly accessible in PyPI, use the `-- --repository pypi` option.
+skip_install = True
+changedir = {toxinidir}
+passenv =
+    TWINE_USERNAME
+    TWINE_PASSWORD
+    TWINE_REPOSITORY
+deps = twine
+commands =
+    python -m twine check dist/*
+    python -m twine upload {posargs:--repository testpypi} dist/*


### PR DESCRIPTION
Putting `tox.ini` back as we currently use it to build and push the package.