### PR TITLE
deps: use xgboost-cpu as default dependency for smaller footprint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,6 +34,7 @@ Installation
 .. code-block:: console
 
     $ pip install xgboost-distribution
+    $ pip install xgboost-distribution[gpu]  # for GPU support
 
 
 `Dependencies`_:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     scikit-learn
-    xgboost>=2.1.4
+    xgboost-cpu>=2.1.4
 
 
 [options.packages.find]
@@ -61,6 +61,9 @@ testing =
     pandas
     pytest
     pytest-cov
+
+gpu = 
+    xgboost>=2.1.4
 
 [options.entry_points]
 # Add here console scripts like:

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,10 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     scikit-learn
-    xgboost-cpu>=2.1.4
+    # for x64 windows and linux we use xgboost-cpu
+    xgboost-cpu>=2.1.4;platform_machine=="x86_64" and (platform_system=="Windows" or platform_system=="Linux")
+    xgboost>=2.1.4;platform_machine!="x86_64"
+
 
 
 [options.packages.find]
@@ -74,7 +77,7 @@ gpu =
 #     fibonacci = xgboost_distribution.skeleton:run
 # And any other entry points, for example:
 # pyscaffold.cli =
-#     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
+#     awesome = pyscaffoldext.awesojme.extension:AwesomeExtension
 
 [tool:pytest]
 # Specify command line options as you would do when invoking pytest directly.

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     scikit-learn
     # for x64 windows and linux we use xgboost-cpu
     xgboost-cpu>=2.1.4;platform_machine=="x86_64" and (platform_system=="Windows" or platform_system=="Linux")
-    xgboost>=2.1.4;platform_machine!="x86_64"
+    xgboost>=2.1.4;platform_machine!="x86_64" or (platform_system!="Windows" and platform_system!="Linux")
 
 
 


### PR DESCRIPTION
Replaced `xgboost` package to `xgboost-cpu` package for smaller footprint.
`xgboost` is moved to GPU extras_require section.

closes #106 

